### PR TITLE
Trusted proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,7 @@ PUSHER_APP_CLUSTER=mt1
 
 MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
+
+# Comma-separated values of trusted proxies addresses
+# @see App\Http\Middleware\TrustProxies
+X_FORWARDED_TRUSTED_PROXIES=

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Http\Request;
 use Fideloper\Proxy\TrustProxies as Middleware;
 
@@ -20,4 +21,23 @@ class TrustProxies extends Middleware
      * @var int
      */
     protected $headers = Request::HEADER_X_FORWARDED_ALL;
+
+    /**
+     * Trusted proxies setup to avoid mixed content error on the production server.
+     *
+     * @param Repository $config
+     *
+     * @link https://github.com/HE-Arc/menu-finder/issues/14
+     * @link https://laravel.com/docs/5.7/requests#configuring-trusted-proxies
+     * @link https://github.com/fideloper/TrustedProxy#why-does-this-matter
+     */
+    public function __construct(Repository $config)
+    {
+        parent::__construct($config);
+
+        $proxies = env('X_FORWARDED_TRUSTED_PROXIES');
+        if (!empty($proxies)) {
+            $this->proxies = explode(',', $proxies);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #14 

### Description
Comme indiqué par @greut dans l'issue #14, la fonction ``asset()``retournait une URL avec le mauvais protocole (HTTP au lieu d'HTTPS) car la classe ``Request``de Laravel ignore par défaut ([pour des raisons de sécurité](https://github.com/fideloper/TrustedProxy#why-does-this-matter)) l'entête HTTP ``X-Forwarded-Proto`` qui sert à connaître le protocole utilisé par le client à l'origine de la requête (elle ignore aussi toutes les autres entêtes ``X-Forwarded-*``).
Pour régler cela, il faut indiquer les *[trust proxies](https://github.com/laravel/laravel/blob/master/app/Http/Middleware/TrustProxies.php#L15)*.

- Utilisation du middleware ``TrustProxies``.
- Création d'une nouvelle variable ``X_FORWARDED_TRUSTED_PROXIES`` dans le fichier ``.env.example``pour changer les *trust proxies* selon l'environnement.